### PR TITLE
Chore: remove warning has_rdoc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           key: bundle-caches{{ checksum "gemspec" }}
           paths:
             - ~/xero_gateway/vendor/bundle
-      - run: bundle exec rake test
+      - run: rake test
   publish:
     docker:
       - image: ehdevops/ruby240:latest
@@ -31,12 +31,6 @@ jobs:
           key: bundle-caches{{ checksum "gemspec" }}
           paths:
             - ~/xero_gateway/vendor/bundle
-      - run: mkdir -p ./tmp/; mkdir -p ./tmp/cache
-      - run: mkdir -p ./tmp/employment-hero/config/
-      - run: echo -e "$PRIVATEKEY_PEM" > ./tmp/employment-hero/config/privatekey.pem
-      - run: echo -e "$ENTRUST_CERT_PEM" > ./tmp/employment-hero/config/entrust-cert.pem
-      - run: echo -e "$ENTRUST_PRIVATE_NOPASS_PEM" > ./tmp/employment-hero/config/entrust-private-nopass.pem
-      - run: bundle exec ruby scripts/publish.rb
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           key: bundle-caches{{ checksum "gemspec" }}
           paths:
             - ~/xero_gateway/vendor/bundle
-      - run: rake test
+      - run: bundle exec rake test
   publish:
     docker:
       - image: ehdevops/ruby240:latest
@@ -31,6 +31,11 @@ jobs:
           key: bundle-caches{{ checksum "gemspec" }}
           paths:
             - ~/xero_gateway/vendor/bundle
+      - run: mkdir -p ./tmp/; mkdir -p ./tmp/cache
+      - run: mkdir -p ./tmp/employment-hero/config/
+      - run: echo -e "$PRIVATEKEY_PEM" > ./tmp/employment-hero/config/privatekey.pem
+      - run: echo -e "$ENTRUST_CERT_PEM" > ./tmp/employment-hero/config/entrust-cert.pem
+      - run: echo -e "$ENTRUST_PRIVATE_NOPASS_PEM" > ./tmp/employment-hero/config/entrust-private-nopass.pem
       - run: bundle exec ruby scripts/publish.rb
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           key: bundle-caches{{ checksum "gemspec" }}
           paths:
             - ~/xero_gateway/vendor/bundle
+      - run: bundle exec ruby scripts/publish.rb
 
 workflows:
   version: 2

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "xero_gateway",
-  "version": "3.2.22",
+  "version": "3.2.23",
   "documents": [
     {
       "name": "README",

--- a/xero_gateway.gemspec
+++ b/xero_gateway.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.email    = "dave@thinkei.com"
   s.homepage = "http://github.com/Thinkei/xero_gateway"
   s.description = "Includes the ability to update Xero payroll data"
-  s.has_rdoc = false
   s.authors  = ["Tim Connor", "Nik Wakelin", "ThinkEI"]
   s.files = ["Gemfile", "LICENSE", "Rakefile", "README.textile", "xero_gateway.gemspec"] + Dir['**/*.rb'] + Dir['**/*.crt']
   s.add_dependency('oauth', '~> 0.4.0')


### PR DESCRIPTION
nothing important, just remove this warning when run `bundle install`
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/employmenthero/.rvm/gems/ruby-2.4.6/bundler/gems/xero_gateway-9d7579d4cd94/xero_gateway.gemspec:9.
```