### PR TITLE
Fix deprecated alias_method_chain 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,5 +10,6 @@ Rake::TestTask.new(:test) do |t|
   t.libs << '.'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = true
+  t.warning = false
 end
 

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "xero_gateway",
-  "version": "3.2.22.alpha",
+  "version": "3.2.23",
   "documents": [
     {
       "name": "README",

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "xero_gateway",
-  "version": "3.2.23",
+  "version": "3.2.23.alpha",
   "documents": [
     {
       "name": "README",

--- a/lib/oauth/oauth_consumer.rb
+++ b/lib/oauth/oauth_consumer.rb
@@ -7,7 +7,7 @@ module OAuth
       end
     end
 
-    alias_method :ssl_client_certificates, :http
-    alias_method :http, :ssl_client_certificates
+    alias_method :http_without_ssl_client_certificates, :http
+    alias_method :http, :http_with_ssl_client_certificates
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 
 require 'test/unit'
-require 'mocha/setup'
+require 'mocha/test_unit'
 require 'shoulda'
 
 require 'libxml'
@@ -13,20 +13,20 @@ module TestHelper
   # environment, and you must have set up a customer key for that account.
   #
   # You can then run the tests against the test environment using the commands (linux or mac):
-  # export STUB_XERO_CALLS=false  
+  # export STUB_XERO_CALLS=false
   # rake test
   # (this probably won't work under OAuth?)
   #
-  
+
   STUB_XERO_CALLS = ENV["STUB_XERO_CALLS"].nil? ? true : (ENV["STUB_XERO_CALLS"] == "true") unless defined? STUB_XERO_CALLS
-  
+
   CONSUMER_KEY    = ENV["CONSUMER_KEY"]    || "fake_key"    unless defined?(CONSUMER_KEY)
   CONSUMER_SECRET = ENV["CONSUMER_SECRET"] || "fake_secret" unless defined?(CONSUMER_SECRET)
-  
+
   # Helper constant for checking regex
   GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ unless defined?(GUID_REGEX)
 
-  
+
   def dummy_invoice(with_line_items = true)
      invoice = XeroGateway::Invoice.new({
        :invoice_type => "ACCREC",
@@ -50,7 +50,7 @@ module TestHelper
      end
      invoice
   end
-      
+
   def dummy_credit_note(with_line_items = true)
      credit_note = XeroGateway::CreditNote.new({
        :type => "ACCRECCREDIT",
@@ -73,7 +73,7 @@ module TestHelper
      end
      credit_note
   end
-      
+
   def dummy_contact
     unique_id = Time.now.to_f
     contact = XeroGateway::Contact.new(:name => STUB_XERO_CALLS ? "CONTACT NAME" : "THE NAME OF THE CONTACT #{unique_id}")
@@ -90,7 +90,7 @@ module TestHelper
 
     contact
   end
-  
+
   def dummy_employee
     unique_id = Time.now.to_f
     employee = XeroGateway::Employee.new({
@@ -120,7 +120,7 @@ module TestHelper
 
   def get_file_as_string(filename)
     data = ''
-    f = File.open(File.dirname(__FILE__) + "/stub_responses/" + filename, "r") 
+    f = File.open(File.dirname(__FILE__) + "/stub_responses/" + filename, "r")
     f.each_line do |line|
       data += line
     end
@@ -215,7 +215,7 @@ module TestHelper
   end
 
   def create_test_manual_journal(params={}, journal_line_params={})
-    params = {      
+    params = {
       :date       => Date.today,
       :narration  => 'test narration',
       :status     => 'POSTED'
@@ -240,9 +240,9 @@ module TestHelper
       journal_line_params[1] = {
         :description  => "SECOND LINE",
         :account_code => "200",
-        :line_amount  => BigDecimal.new("-100"),        
+        :line_amount  => BigDecimal.new("-100"),
         :tracking     => XeroGateway::TrackingCategory.new(:name => "blah2", :options => "hello2")
-      }.merge(params_line_1)      
+      }.merge(params_line_1)
 
       # Create line_items from line_item_params
       journal_line_params.each do |journal_line|
@@ -267,7 +267,7 @@ module TestHelper
                                                 :pay_period_end_date => Date.today + 1.month,
                                                 :pay_period_start_date => Date.today,
                                                 :leave_period_status => "SCHEDULED"
-                                              )  
+                                              )
                                             ]
                         })
     leave_application


### PR DESCRIPTION
The reason we need to bump version here is after [this PR](https://github.com/Thinkei/xero_gateway/pull/36) the author did not bump gem version

Change:
- Fix bug alias_method_chain